### PR TITLE
Update CLI version to enforce workflow failure on scan failures and Updated Readme to correct version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Run Accuknox SAST: Opengrep"
-        uses: accuknox/sast-scan-opengrep-action@1.0.1
+        uses: accuknox/sast-scan-opengrep-action@v1.0.1
         with:
           accuknox_endpoint: ${{ secrets.ACCUKNOX_ENDPOINT }}
           accuknox_token: ${{ secrets.ACCUKNOX_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
 
         # Download latest ASPM Scanner
         echo "Downloading AccuKnox ASPM Scanner..."
-        curl -L https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.4/accuknox-aspm-scanner -o accuknox-aspm-scanner
+        curl -L https://github.com/accuknox/aspm-scanner-cli/releases/download/v0.13.8/accuknox-aspm-scanner -o accuknox-aspm-scanner
         chmod +x accuknox-aspm-scanner
 
         # Determine soft-fail argument


### PR DESCRIPTION
Chore: update CLI version in action workflow

The updated CLI now correctly enforces failure behaviour across all scan types.
This commit updates the action configuration to use the new CLI version, so workflow runs fail when any scan reports a failure.