### PR TITLE
[CNAPP-23316] remove commit-ref

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,6 @@ runs:
         ./accuknox-aspm-scanner scan --keep-results $SOFT_FAIL_ARG sast \
           --command "." \
           --repo-url "https://github.com/${GITHUB_REPOSITORY}.git" \
-          --commit-ref "${GITHUB_REF#refs/heads/}" \
           --commit-sha "${GITHUB_SHA}" \
           --pipeline-id "$PIPELINE_ID" \
           --job-url "$JOB_URL" \


### PR DESCRIPTION
cspm-scanner-cli picks commit-ref based on the checked out branch by default.